### PR TITLE
Fixes for grpc-gateway and websocket requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,49 @@
-# Streaming gRPC-web Example
+# gRPC Sending Methods
 
-An example of grpc-web using a streaming dog tracker. This is a simple example of streaming grpc to grpc-web, and does not use an actual datastore apart from the list of dogs created in memory.
+Examples of streaming and otherwise sending gRPC from a go backend to clients using a dog tracker. 
+Data is sent from the backend via these methods:
+- **gRPC**
+- **grpc-gateway**(JSON over http) 
+- **grpc-gateway with websockets**(JSON over ws), 
+- **grpc-web**(http2)
 
-## Building:
+
+## Server:
 
 1. Set up `$GOPATH` and add `$GOPATH/bin` to your `$PATH`
-2. Run `go get -u github.com/golang/protobuf/protoc-gen-go`
+2. Fetch the following dependencies:
+```
+go get -u github.com/golang/protobuf/protoc-gen-go
+go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+go get -u github.com/golang/protobuf/protoc-gen-go
+```
 3. `cd proto`
 4. Run `./generate.sh`
 5. For Go 1.11 vendoring, set envionmental variable `GO111MODULE=on`.
 6. Run `go mod vendor` to update vendor folder.
-7. `go build` or `go run`.
+7. `go build main.go` or `go run main.go` in backend directory.
+
+
+## Clients:
+
+### Web-WS
+Javascript web client using json over websockets for streaming
+1. `npm i`
+2. `npm start`
+3. Navigate to [http://localhost:8080](http://localhost:8080)
+
+### Web-GRPC
+Javascript web client using grpc over grpc-web
+1. `npm i`
+2. `npm start`
+3. Navigate to [https://localhost:8080](http://localhost:8080)
+
+### Use:
+
+Look at the backend logs to see the initialization of each dog location ID. 
+The IDs listed can be entered into the client and used to receive dogs that are currently in those locations.
+
 
 ## Certs:
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -36,7 +36,7 @@ func main() {
 	services.InitializeDogs()
 	grpcPort := 50051
 	httpsPort := 9091
-	gatewayPort := 8080
+	gatewayPort := 8081
 
 	// setup for gRPC server
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", grpcPort))

--- a/backend/services/dog_test.go
+++ b/backend/services/dog_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"github.com/marcsj/streaming-grpc-web-example/backend/dog"
+	"golang.org/x/net/websocket"
 	"google.golang.org/grpc"
 	"io"
 	"log"
@@ -10,7 +11,7 @@ import (
 	"time"
 )
 
-func TestDogTrackServer_TrackDogs(t *testing.T) {
+func TestGRPCServer_TrackDogs(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -47,5 +48,27 @@ func TestDogTrackServer_TrackDogs(t *testing.T) {
 			"Owned by: ", dog.OwnerId,
 			"Status: ", dog.Status.String(),
 			dog.Location.X, dog.Location.Y)
+	}
+}
+
+func TestWSServer_TrackDogs(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	var err error
+	conn, err := websocket.Dial("ws://localhost:8081/v1/dogs/track", "", "http://localhost/")
+	if err != nil {
+		t.Error(err)
+	}
+	conn.Write([]byte("test message"))
+	connectionBytes := make([]byte, 256)
+	_, err = conn.Read(connectionBytes)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(string(connectionBytes))
+	err = conn.Close()
+	if err != nil {
+		t.Error(err)
 	}
 }

--- a/proto/dog.proto
+++ b/proto/dog.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package dog;
 
-// import "google/api/annotations.proto";
+import "google/api/annotations.proto";
 
 message TrackRequest {
     string location_id = 1;
@@ -37,9 +37,8 @@ enum DogStatus {
 
 service DogTrack {
     rpc TrackDogs (TrackRequest) returns (stream Dog) {
-        // option (google.api.http) = {
-        //     post: "/v1/dogs/track"
-        //     body: "*"
-        // };
+         option (google.api.http) = {
+             get: "/v1/dogs/track"
+         };
     }
 }

--- a/proto/generate.sh
+++ b/proto/generate.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 set -eu
 
-mkdir -p ../keys
-mkdir -p ../backend/dog
-mkdir -p ../web-grpc/generated
+KEY_DIR=../keys
+BACKEND_DIR=../backend
+WEB_DIR=../web-grpc/generated
+GEN_TS_DIR=../web-grpc/node_modules/.bin/protoc-gen-ts
 
+
+mkdir -p $KEY_DIR
+mkdir -p $BACKEND_DIR
+mkdir -p $WEB_DIR
+
+# the following two lines are due to extensions generation in protoc-gen-ts
+mkdir -p $WEB_DIR/google/api
+touch $WEB_DIR/google/api/annotations_pb.js
+
+GEN_NAME="dog"
 protoc -I ./ \
   -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
-  --swagger_out=logtostderr=true:../backend/dog \
-  --grpc-gateway_out=logtostderr=true:../backend/dog \
-  --plugin=protoc-gen-ts=../web-grpc/node_modules/.bin/protoc-gen-ts \
-  --js_out=import_style=commonjs,binary:../web-grpc/generated \
-  --ts_out=service=true:../web-grpc/generated \
-  --go_out=plugins=grpc:../backend/dog \
-  dog.proto
+  --swagger_out=logtostderr=true:$BACKEND_DIR/$GEN_NAME \
+  --grpc-gateway_out=logtostderr=true:$BACKEND_DIR/$GEN_NAME \
+  --plugin=protoc-gen-ts=$GEN_TS_DIR \
+  --js_out=import_style=commonjs,binary:$WEB_DIR \
+  --ts_out=service=true:$WEB_DIR \
+  --go_out=plugins=grpc:$BACKEND_DIR/$GEN_NAME \
+  $GEN_NAME.proto

--- a/web-ws/src/index.js
+++ b/web-ws/src/index.js
@@ -3,18 +3,10 @@ window.onSubmit = event => {
   const locationID = document.querySelector("#location-id").value;
   const floorID = "1";
   const ws = new WebSocket(
-    // `ws://${window.location.hostname}:8080/v1/dogs/track`
-    `ws://${window.location.hostname}:8080/`
+    `ws://${window.location.hostname}:8081/v1/dogs/track?location_id=${locationID}&floor_id=${floorID}`
   );
   ws.addEventListener("open", event => {
     console.log("open", event);
-    ws.send(
-      JSON.stringify({
-        command: "dogs.track",
-        locationID,
-        floorID
-      })
-    );
   });
   ws.addEventListener("message", event => {
     console.log("message", event);


### PR DESCRIPTION
Fixes include:
- Getting successful websocket requests with our gRPC requests.
- Fixing issue with grpc-web on client and requiring annotations.
- Adding more detailed instructions for clients.